### PR TITLE
Fixed component installation instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
           Install Rust <code>nightly</code> and <code>rust-src</code> via Rustup by typing the following snippet into a terminal.
           The <code>rust-src</code> component is required to allow Rust to compile <code>libcore</code> for any chip being targeted.
           <pre><code>
-            $ rustup component add nightly rust-src
+            $ rustup component add --toolchain nightly rust-src
           </code></pre>
         </li>
         <li>Done!


### PR DESCRIPTION
Originally specified instructions failed for me.  Specifying the toolchain with the toolchain flag fixed it.